### PR TITLE
feat: simplify init.js and add symlink support for plugin installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,14 @@ The init script automatically:
 # Configure for Claude Code (claude.ai/code)
 node init.js --claude-code
 
-# Specify UE project and install plugin
-node init.js --project "/path/to/project.uproject" --install-plugin
+# Specify UE project (automatically installs plugin)
+node init.js --project "/path/to/project.uproject"
+
+# Install with symlink for development (recommended)
+node init.js --project "/path/to/project.uproject" --symlink
 
 # Non-interactive with all options
-node init.js --claude-code --project "/path/to/project.uproject" --install-plugin --no-interactive
+node init.js --claude-code --project "/path/to/project.uproject" --no-interactive
 ```
 
 ## 🛠 Available Tools
@@ -139,15 +142,25 @@ Key Features:
 ### Plugin Development
 
 **Recommended: Use symlinks for hot reloading**
+
+The init script now supports creating symlinks automatically:
 ```bash
-# Create a symlink from your UE project to the git repo
-ln -s /path/to/UEMCP/plugin "/path/to/UE/Project/Plugins/UEMCP"
+# Install with symlink (recommended for development)
+node init.js --project "/path/to/project.uproject" --symlink
 
-# Now edit directly in git repo - changes reflect immediately in UE
-code /path/to/UEMCP/plugin/
+# Or let it ask you interactively (defaults to symlink)
+node init.js --project "/path/to/project.uproject"
+```
 
+Benefits of symlinking:
+- ✅ Edit plugin files directly in the git repository
+- ✅ Changes reflect immediately after `restart_listener()`
+- ✅ No need to copy files back and forth
+- ✅ Version control friendly
+
+```bash
 # In UE Python console, reload changes without restarting:
-restart_listener()  # Hot reload changes
+restart_listener()  # Hot reload your changes
 
 # Available helpers:
 status()            # Check if running

--- a/docs/plugin-installation.md
+++ b/docs/plugin-installation.md
@@ -18,8 +18,14 @@ The UEMCP system consists of two main components:
 
 #### Option A: Using init.js (Recommended)
 ```bash
-# Run the init script with --install-plugin flag
-node init.js --project "/path/to/your/project.uproject" --install-plugin
+# Run the init script (automatically installs plugin when project is specified)
+node init.js --project "/path/to/your/project.uproject"
+
+# For development, use symlink (recommended):
+node init.js --project "/path/to/your/project.uproject" --symlink
+
+# For production deployment, use copy:
+node init.js --project "/path/to/your/project.uproject" --copy
 ```
 
 #### Option B: Manual Installation
@@ -27,9 +33,16 @@ node init.js --project "/path/to/your/project.uproject" --install-plugin
 # Create Plugins directory if it doesn't exist
 mkdir -p "<YOUR_UE_PROJECT>/Plugins"
 
-# Copy plugin to your project
+# For development (symlink):
+ln -s <PATH_TO_UEMCP>/plugin "<YOUR_UE_PROJECT>/Plugins/UEMCP"
+
+# For production (copy):
 cp -r <PATH_TO_UEMCP>/plugin "<YOUR_UE_PROJECT>/Plugins/UEMCP"
 ```
+
+**Symlink vs Copy:**
+- **Symlink** (Development): Changes in git repo reflect immediately, supports hot reload
+- **Copy** (Production): Self-contained, no dependency on git repo location
 
 ### 2. Enable Required Plugins
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,8 +15,8 @@ That's it! The init script handles everything automatically.
 ### Advanced Setup Options
 
 ```bash
-# Install with plugin to your Unreal project
-node init.js --project "/path/to/your/ue/project" --install-plugin
+# Install to your Unreal project (automatically installs plugin)
+node init.js --project "/path/to/your/ue/project"
 
 # Non-interactive mode (great for CI/CD)
 node init.js --no-interactive --project "/path/to/project"
@@ -89,7 +89,7 @@ For full functionality, install the UEMCP plugin to your UE project:
 
 ```bash
 # If you didn't do this during init, run:
-node init.js --project "/path/to/project.uproject" --install-plugin
+node init.js --project "/path/to/project.uproject"
 ```
 
 The plugin enables:

--- a/init.js
+++ b/init.js
@@ -8,9 +8,10 @@
  *   node init.js [options]
  * 
  * Options:
- *   --project <path>    Path to Unreal Engine project
+ *   --project <path>    Path to Unreal Engine project (will install plugin)
+ *   --symlink           Create symlink instead of copying plugin (recommended for development)
+ *   --copy              Copy plugin files instead of symlinking
  *   --no-interactive    Run without prompts
- *   --install-plugin    Install plugin to UE project
  *   --skip-claude       Skip Claude Desktop configuration
  *   --claude-code       Configure Claude Code (claude.ai/code) MCP
  *   --help              Show this help
@@ -27,9 +28,9 @@ const args = process.argv.slice(2);
 const options = {
     project: null,
     interactive: true,
-    installPlugin: false,
     skipClaude: false,
     claudeCode: false,
+    symlink: null, // null = ask, true = symlink, false = copy
     help: false
 };
 
@@ -41,14 +42,17 @@ for (let i = 0; i < args.length; i++) {
         case '--no-interactive':
             options.interactive = false;
             break;
-        case '--install-plugin':
-            options.installPlugin = true;
-            break;
         case '--skip-claude':
             options.skipClaude = true;
             break;
         case '--claude-code':
             options.claudeCode = true;
+            break;
+        case '--symlink':
+            options.symlink = true;
+            break;
+        case '--copy':
+            options.symlink = false;
             break;
         case '--help':
         case '-h':
@@ -65,16 +69,17 @@ Usage:
   node init.js [options]
 
 Options:
-  --project <path>    Path to Unreal Engine project
+  --project <path>    Path to Unreal Engine project (will install plugin)
+  --symlink           Create symlink instead of copying plugin (recommended for development)
+  --copy              Copy plugin files instead of symlinking
   --no-interactive    Run without prompts
-  --install-plugin    Install plugin to UE project
   --skip-claude       Skip Claude Desktop configuration
   --claude-code       Configure Claude Code (claude.ai/code) MCP
   --help              Show this help
 
 Examples:
   node init.js
-  node init.js --project "/path/to/project" --install-plugin
+  node init.js --project "/path/to/project" --symlink
   node init.js --no-interactive --skip-claude
   node init.js --claude-code
 `);
@@ -152,8 +157,8 @@ function copyDir(src, dest) {
 }
 
 // Install plugin to Unreal project
-async function installPlugin(projectPath) {
-    log.section('Installing UEMCP Plugin to Unreal Project...');
+async function installPlugin(projectPath, useSymlink = false) {
+    log.section(`${useSymlink ? 'Symlinking' : 'Installing'} UEMCP Plugin to Unreal Project...`);
     
     const pluginsDir = path.join(projectPath, 'Plugins');
     const uemcpPluginDir = path.join(pluginsDir, 'UEMCP');
@@ -179,27 +184,51 @@ async function installPlugin(projectPath) {
     
     // Check if plugin already exists
     if (fs.existsSync(uemcpPluginDir)) {
-        log.warning('UEMCP plugin already exists in project.');
-        if (options.interactive) {
-            const answer = await question('Overwrite existing plugin? (y/N): ');
-            if (answer.toLowerCase() !== 'y') {
-                log.info('Skipping plugin installation.');
+        // Check if it's already a symlink
+        const stats = fs.lstatSync(uemcpPluginDir);
+        if (stats.isSymbolicLink()) {
+            const linkTarget = fs.readlinkSync(uemcpPluginDir);
+            log.warning(`UEMCP plugin already exists as symlink → ${linkTarget}`);
+            if (options.interactive) {
+                const answer = await question('Update existing symlink? (y/N): ');
+                if (answer.toLowerCase() !== 'y') {
+                    log.info('Keeping existing symlink.');
+                    return false;
+                }
+            } else {
+                log.info('Keeping existing symlink.');
                 return false;
             }
         } else {
-            log.info('Skipping plugin installation (already exists).');
-            return false;
+            log.warning('UEMCP plugin already exists in project.');
+            if (options.interactive) {
+                const answer = await question('Replace existing plugin? (y/N): ');
+                if (answer.toLowerCase() !== 'y') {
+                    log.info('Skipping plugin installation.');
+                    return false;
+                }
+            } else {
+                log.info('Skipping plugin installation (already exists).');
+                return false;
+            }
         }
         
-        // Remove existing plugin
+        // Remove existing plugin or symlink
         fs.rmSync(uemcpPluginDir, { recursive: true, force: true });
     }
     
-    // Copy plugin
+    // Install plugin (copy or symlink)
     try {
-        log.info('Copying plugin files...');
-        copyDir(sourcePluginDir, uemcpPluginDir);
-        log.success('Plugin installed successfully!');
+        if (useSymlink) {
+            log.info(`Creating symlink: ${uemcpPluginDir} → ${sourcePluginDir}`);
+            fs.symlinkSync(sourcePluginDir, uemcpPluginDir, 'junction');
+            log.success('Plugin symlinked successfully!');
+            log.info('💡 Tip: Changes to plugin code will be reflected immediately after restart_listener()');
+        } else {
+            log.info('Copying plugin files...');
+            copyDir(sourcePluginDir, uemcpPluginDir);
+            log.success('Plugin copied successfully!');
+        }
         
         // Update .uproject file to enable the plugin
         const uprojectFiles = fs.readdirSync(projectPath).filter(f => f.endsWith('.uproject'));
@@ -336,16 +365,28 @@ async function init() {
     }
     
     let validProjectPath = null;
+    let shouldInstallPlugin = false;
     if (ueProjectPath) {
         const expandedPath = ueProjectPath.replace(/^~/, os.homedir());
         if (fs.existsSync(expandedPath)) {
             validProjectPath = expandedPath;
             log.success(`Project path verified: ${expandedPath}`);
             
-            // Ask about plugin installation if not specified
-            if (options.interactive && !options.installPlugin) {
+            // Plugin installation is automatic when project is specified
+            // Ask for confirmation in interactive mode
+            shouldInstallPlugin = true;
+            if (options.interactive) {
                 const answer = await question('Install UEMCP plugin to this project? (Y/n): ');
-                options.installPlugin = answer.toLowerCase() !== 'n';
+                shouldInstallPlugin = answer.toLowerCase() !== 'n';
+                
+                // Ask about symlink vs copy if not specified
+                if (shouldInstallPlugin && options.symlink === null) {
+                    console.log('\nHow would you like to install the plugin?');
+                    console.log('  1. Symlink (recommended for development - hot reload support)');
+                    console.log('  2. Copy (recommended for production)');
+                    const methodAnswer = await question('Choose method (1/2) [1]: ');
+                    options.symlink = methodAnswer !== '2';
+                }
             }
         } else {
             log.error(`Directory not found: ${expandedPath}`);
@@ -353,9 +394,11 @@ async function init() {
         }
     }
     
-    // Install plugin if requested
-    if (options.installPlugin && validProjectPath) {
-        await installPlugin(validProjectPath);
+    // Install plugin if project path provided
+    if (shouldInstallPlugin && validProjectPath) {
+        // Default to symlink in non-interactive mode if not specified
+        const useSymlink = options.symlink !== null ? options.symlink : true;
+        await installPlugin(validProjectPath, useSymlink);
     }
     
     // Configure Claude Desktop
@@ -501,8 +544,9 @@ testProcess.on('close', (code) => {
     }
     if (validProjectPath) {
         console.log(`  • Project: ${validProjectPath}`);
-        if (options.installPlugin) {
-            console.log(`  • Plugin: Installed to project`);
+        if (shouldInstallPlugin) {
+            const useSymlink = options.symlink !== null ? options.symlink : true;
+            console.log(`  • Plugin: ${useSymlink ? 'Symlinked' : 'Copied'} to project`);
         }
     }
     
@@ -517,7 +561,7 @@ testProcess.on('close', (code) => {
         console.log(`  ${stepNum++}. Visit claude.ai/code and say "List available UEMCP tools"`);
     }
     console.log(`  ${stepNum++}. Test locally: node test-connection.js`);
-    if (validProjectPath && options.installPlugin) {
+    if (validProjectPath && shouldInstallPlugin) {
         console.log(`  ${stepNum++}. Open your project in Unreal Editor`);
         console.log(`  ${stepNum++}. The UEMCP plugin should load automatically`);
     }


### PR DESCRIPTION
- Remove redundant --install-plugin flag (now automatic with --project)
- Add --symlink and --copy options for plugin installation method
- Add interactive prompt to choose between symlink (dev) or copy (prod)
- Update all documentation to reflect new options
- Make symlink the default for development workflows
- Improve plugin installation messages and error handling
- Detect and handle existing symlinks properly

This makes the developer experience much smoother by enabling hot reload support through symlinks while still supporting traditional copying for production deployments.