### PR TITLE
fix: Actor organize tool

### DIFF
--- a/server/src/tools/actors/organize.ts
+++ b/server/src/tools/actors/organize.ts
@@ -41,7 +41,8 @@ export class ActorOrganizeTool extends ActorTool<ActorOrganizeArgs> {
   protected async execute(args: ActorOrganizeArgs): Promise<ToolResponse> {
     const result = await this.executePythonCommand('actor.organize', args);
     
-    const organizedCount = (result.organizedCount as number) || 0;
+    const organizedCount = (result.count as number) || 0;
+    const organizedActors = (result.organizedActors as string[]) || [];
     
     let text = `✓ Organized ${organizedCount} actor${organizedCount !== 1 ? 's' : ''} into folder: ${args.folder}\n`;
     
@@ -51,13 +52,13 @@ export class ActorOrganizeTool extends ActorTool<ActorOrganizeArgs> {
       text += `  Method: Pattern matching "${args.pattern}"`;
     }
     
-    if (result.actors && Array.isArray(result.actors) && result.actors.length > 0) {
+    if (organizedActors.length > 0) {
       text += '\n  Organized actors:\n';
-      (result.actors as string[]).slice(0, 10).forEach(actor => {
+      organizedActors.slice(0, 10).forEach(actor => {
         text += `    - ${actor}\n`;
       });
-      if (result.actors.length > 10) {
-        text += `    ... and ${result.actors.length - 10} more`;
+      if (organizedActors.length > 10) {
+        text += `    ... and ${organizedActors.length - 10} more`;
       }
     }
     


### PR DESCRIPTION
## Summary
Critical fixes for MCP tools including actor organization, viewport tools, and Python bridge connection issues.

## Changes

### Actor Organize Tool Fix 🔧
- **Fixed reporting bug**: Tool was working but showing "0 actors organized"
- **Problem**: TypeScript expected `organizedCount` and `actors` but Python returned `count` and `organizedActors`
- **Solution**: Updated TypeScript tool to read correct property names from Python response
- **Impact**: Now correctly reports actual number of organized actors and their names

### Code Quality Improvements ✨
- Added proper OutlinerNode interface replacing complex type assertions
- Extracted formatFileSize to shared utility function  
- Improved PythonResult interface with common response properties
- Removed production line count comments
- Fixed unnecessary type assertions

## Test Results
```
✅ ESLint: 0 errors
✅ TypeScript: Compiles successfully
✅ Python linting: Passes
✅ All CI checks pass
```

## Testing Required
These fixes require a fresh MCP server restart to take effect:
1. Exit Claude Code completely
2. Restart Claude Code (`claude -c`)
3. Test actor_organize tool - should now show correct counts
4. Test viewport_focus tool - should work without errors