### PR TITLE
docs: Add documentation for material management tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ node init.js --claude-code --project "/path/to/project.uproject" --no-interactiv
 
 ## 🛠 Available Tools
 
-UEMCP provides 25 tools to Claude for controlling Unreal Engine:
+UEMCP provides 29 tools to Claude for controlling Unreal Engine:
 
 ### Project & Assets
 - **project_info** - Get current project information
@@ -130,6 +130,12 @@ UEMCP provides 25 tools to Claude for controlling Unreal Engine:
 - **viewport_bounds** - Get current viewport boundaries and visible area
 - **viewport_fit** - Auto-frame actors in viewport
 - **viewport_look_at** - Point camera at specific coordinates or actor with automatic Yaw calculation
+
+### Material Management
+- **material_list** - List and filter materials in the project
+- **material_info** - Get detailed material information including parameters and parent material
+- **material_create** - Create new materials or material instances with customizable parameters
+- **material_apply** - Apply materials to actors' static mesh components
 
 ### 🔍 Validation Feature
 
@@ -169,6 +175,41 @@ actor_modify({
   - `help({})` - Overview with categories and common workflows
   - `help({ tool: "actor_spawn" })` - Detailed examples for specific tools
   - `help({ category: "viewport" })` - List all tools in a category
+
+### Example: Material Management Tools
+
+```javascript
+// List all materials in a folder
+material_list({ path: "/Game/Materials", pattern: "Wood" })
+
+// Get detailed information about a material
+material_info({ materialPath: "/Game/Materials/M_Wood_Pine" })
+
+// Create a simple sand material
+material_create({ 
+  materialName: "M_Sand", 
+  baseColor: { r: 0.8, g: 0.7, b: 0.5 },
+  roughness: 0.8,
+  metallic: 0.0
+})
+
+// Create a material instance from a parent
+material_create({
+  parentMaterialPath: "/Game/Materials/M_Master",
+  instanceName: "MI_CustomWall",
+  parameters: {
+    "BaseColor": { r: 0.5, g: 0.5, b: 0.7 },
+    "Roughness": 0.6
+  }
+})
+
+// Apply material to an actor
+material_apply({
+  actorName: "Floor_01",
+  materialPath: "/Game/Materials/M_Sand",
+  slotIndex: 0
+})
+```
 
 ### Example: Using python_proxy for Complex Operations
 

--- a/plugin/Content/Python/ops/system.py
+++ b/plugin/Content/Python/ops/system.py
@@ -32,6 +32,7 @@ class SystemOperations:
                 'level': ['level_actors', 'level_save', 'level_outliner'],
                 'viewport': ['viewport_screenshot', 'viewport_camera', 'viewport_mode', 'viewport_focus', 
                            'viewport_render_mode', 'viewport_bounds', 'viewport_fit', 'viewport_look_at'],
+                'material': ['material_list', 'material_info', 'material_create', 'material_apply'],
                 'advanced': ['python_proxy'],
                 'system': ['test_connection', 'restart_listener', 'ue_logs', 'help']
             }
@@ -76,6 +77,57 @@ class SystemOperations:
                     'examples': [
                         'python_proxy({ code: "import unreal\\nprint(unreal.SystemLibrary.get_project_name())" })',
                         'python_proxy({ code: "result = len(unreal.EditorLevelLibrary.get_all_level_actors())" })'
+                    ]
+                },
+                'material_list': {
+                    'description': 'List materials in the project with optional filtering',
+                    'parameters': {
+                        'path': 'Content browser path to search (default: /Game)',
+                        'pattern': 'Filter pattern for material names (optional)',
+                        'limit': 'Maximum number of materials to return (default: 50)'
+                    },
+                    'examples': [
+                        'material_list({ path: "/Game/Materials" })',
+                        'material_list({ pattern: "Wood", limit: 20 })'
+                    ]
+                },
+                'material_info': {
+                    'description': 'Get detailed information about a material',
+                    'parameters': {
+                        'materialPath': 'Path to the material (e.g., /Game/Materials/M_Wood)'
+                    },
+                    'examples': [
+                        'material_info({ materialPath: "/Game/Materials/M_Wood_Pine" })'
+                    ]
+                },
+                'material_create': {
+                    'description': 'Create a new material or material instance',
+                    'parameters': {
+                        'materialName': 'Name for new material (creates simple material)',
+                        'parentMaterialPath': 'Path to parent material (creates material instance)',
+                        'instanceName': 'Name for new material instance',
+                        'targetFolder': 'Destination folder (default: /Game/Materials)',
+                        'baseColor': 'RGB color values {r, g, b} in 0-1 range',
+                        'metallic': 'Metallic value (0-1)',
+                        'roughness': 'Roughness value (0-1)',
+                        'emissive': 'RGB emissive color {r, g, b}',
+                        'parameters': 'Parameter overrides for material instance'
+                    },
+                    'examples': [
+                        'material_create({ materialName: "M_Sand", baseColor: {r: 0.8, g: 0.7, b: 0.5}, roughness: 0.8 })',
+                        'material_create({ parentMaterialPath: "/Game/M_Master", instanceName: "MI_Custom", parameters: { BaseColor: {r: 0.5, g: 0.5, b: 0.7} } })'
+                    ]
+                },
+                'material_apply': {
+                    'description': 'Apply a material to an actor',
+                    'parameters': {
+                        'actorName': 'Name of the actor to apply material to',
+                        'materialPath': 'Path to the material to apply',
+                        'slotIndex': 'Material slot index (default: 0)'
+                    },
+                    'examples': [
+                        'material_apply({ actorName: "Floor_01", materialPath: "/Game/Materials/M_Sand" })',
+                        'material_apply({ actorName: "Wall_01", materialPath: "/Game/Materials/M_Brick", slotIndex: 1 })'
                     ]
                 }
             }


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation for the new material management MCP tools that were just merged.

## Changes
- Updated tool count from 25 to 29 in README
- Added Material Management section to Available Tools listing
- Added usage examples for all 4 material tools with code snippets
- Updated help system to include material tools in 'material' category
- Added detailed help entries for `material_list`, `material_info`, `material_create`, and `material_apply`

## Documentation Coverage
The material tools are now fully documented with:
- Tool descriptions in README
- Usage examples showing common workflows
- Integration into the help system
- Proper categorization for discoverability

This ensures users can easily discover and understand how to use the new material management capabilities.

🤖 Generated with [Claude Code](https://claude.ai/code)