### PR TITLE
Fix batch_spawn indentation bug and command routing

### DIFF
--- a/plugin/Content/Python/ops/actor.py
+++ b/plugin/Content/Python/ops/actor.py
@@ -668,32 +668,32 @@ class ActorOperations:
             return {"success": False, "error_data": {
                 "assetPath": asset_path, "error": f"Failed to load asset: {asset_path}"}}
 
-            # Spawn actor
-            spawned_actor = self._spawn_actor_with_params(asset, actor_config)
-            if not spawned_actor:
-                return {"success": False, "error_data": {
-                    "assetPath": asset_path, "error": "Spawn failed - check location for collisions"}}
+        # Spawn actor
+        spawned_actor = self._spawn_actor_with_params(asset, actor_config)
+        if not spawned_actor:
+            return {"success": False, "error_data": {
+                "assetPath": asset_path, "error": "Spawn failed - check location for collisions"}}
 
-            # Configure spawned actor
-            actor_name = self._configure_spawned_actor(
-                spawned_actor, actor_config, common_folder)
+        # Configure spawned actor
+        actor_name = self._configure_spawned_actor(
+            spawned_actor, actor_config, common_folder)
 
-            # Build actor data
-            location = actor_config.get("location", [0, 0, 0])
-            rotation = actor_config.get("rotation", [0, 0, 0])
-            scale = actor_config.get("scale", [1, 1, 1])
+        # Build actor data
+        location = actor_config.get("location", [0, 0, 0])
+        rotation = actor_config.get("rotation", [0, 0, 0])
+        scale = actor_config.get("scale", [1, 1, 1])
 
-            return {
-                "success": True,
-                "actor_data": {
-                    "name": actor_name,
-                    "assetPath": asset_path,
-                    "location": location,
-                    "rotation": rotation,
-                    "scale": scale,
-                    "_actor_ref": spawned_actor,
-                }
+        return {
+            "success": True,
+            "actor_data": {
+                "name": actor_name,
+                "assetPath": asset_path,
+                "location": location,
+                "rotation": rotation,
+                "scale": scale,
+                "_actor_ref": spawned_actor,
             }
+        }
 
     def _spawn_actor_with_params(self, asset, actor_config):
         """Spawn an actor with given parameters.

--- a/server/src/tools/actors/batch-spawn.ts
+++ b/server/src/tools/actors/batch-spawn.ts
@@ -112,7 +112,7 @@ export class BatchSpawnTool extends ActorTool<BatchSpawnArgs> {
     }
 
     // Execute batch spawn command
-    const result = await this.executePythonCommand('actor.batch_spawn', {
+    const result = await this.executePythonCommand('actor_batch_spawn', {
       actors: args.actors,
       commonFolder: args.commonFolder,
       validate: args.validate ?? true, // Default to true


### PR DESCRIPTION
## Summary
- **Fix critical indentation bug** in `_spawn_single_batch_actor` method causing `'NoneType' object is not subscriptable` errors
- **Fix TypeScript command routing** from `actor.batch_spawn` to `actor_batch_spawn` to match Python registry naming

## Root Cause
The batch_spawn functionality was completely broken due to:

1. **Python indentation error**: Actor spawning logic was incorrectly nested inside the asset validation failure block
2. **Command routing mismatch**: TypeScript used dot notation while Python registry expects underscore notation

## Changes Made
### Python Fix (`plugin/Content/Python/ops/actor.py`)
- Corrected indentation in `_spawn_single_batch_actor` (lines 671-696)
- Moved spawning logic to proper scope after successful asset validation
- This prevents attempting to spawn with `None` asset, which caused the NoneType error

### TypeScript Fix (`server/src/tools/actors/batch-spawn.ts`)  
- Changed command from `'actor.batch_spawn'` to `'actor_batch_spawn'`
- Aligns with Python command registry naming convention

## Test Results
✅ batch_spawn now works correctly via Python API
✅ No more "'NoneType' object is not subscriptable" errors
✅ Performance timing and validation working as expected

## Performance Impact
This fix restores the batch_spawn performance optimizations:
- Viewport disabling during bulk operations
- Built-in execution time measurement  
- Optional validation for maximum performance
- Proper error handling for individual actor failures

🤖 Generated with [Claude Code](https://claude.ai/code)