### PR TITLE
fix: update release workflow for correct file references

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,10 +56,15 @@ jobs:
         cp -r server UEMCP-Full-${{ github.ref_name }}/
         cp -r plugin UEMCP-Full-${{ github.ref_name }}/
         cp -r docs UEMCP-Full-${{ github.ref_name }}/
-        cp README.md LICENSE VERSIONING.md CLAUDE.md UEMCP-Full-${{ github.ref_name }}/
+        cp README.md CLAUDE.md PLAN.md RELEASE_PROCESS.md UEMCP-Full-${{ github.ref_name }}/
+        
+        # Copy LICENSE if it exists
+        if [ -f LICENSE ]; then
+          cp LICENSE UEMCP-Full-${{ github.ref_name }}/
+        fi
         
         # Copy setup scripts
-        cp init.js init.sh init.ps1 UEMCP-Full-${{ github.ref_name }}/
+        cp setup.sh UEMCP-Full-${{ github.ref_name }}/
         
         # Create zip
         zip -r UEMCP-Full-${{ github.ref_name }}.zip UEMCP-Full-${{ github.ref_name }}/
@@ -89,7 +94,7 @@ jobs:
           ```bash
           unzip UEMCP-Full-${{ github.ref_name }}.zip
           cd UEMCP-Full-${{ github.ref_name }}
-          node init.js
+          ./setup.sh
           ```
           
           #### Individual Components


### PR DESCRIPTION
## Issue

The v0.9.0 release CI failed because the release workflow was trying to copy files that don't exist:
-  (doesn't exist)
- , ,  (don't exist)

## Changes

- Replace missing  with 
- Replace non-existent init scripts with [H[2J[3J[0;34m╔════════════════════════════════════════╗[0m
[0;34m║        UEMCP Complete Setup            ║[0m
[0;34m║     Environment + MCP Configuration    ║[0m
[0;34m╚════════════════════════════════════════╝[0m
[0;34mDetected OS: macos[0m

[0;36mChecking Node.js...[0m
[0;32m✓ Node.js v24.4.0[0m
[0;32m✓ npm 11.5.2[0m

[0;36mChecking Python...[0m
[0;32m✓ Python 3.13.5[0m

[0;36mInstalling Node.js dependencies...[0m

up to date, audited 252 packages in 327ms

54 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
[0;32m✓ Node.js dependencies installed[0m

[0;36mBuilding MCP server...[0m

> uemcp-server@0.9.0 build
> tsc

[0;32m✓ Server built successfully![0m

[0;36mSetting up Python environment...[0m
[0;34mExisting virtual environment found at /Users/antic/github.com/atomantic/UEMCP/venv[0m
- Add conditional  copy to prevent failures
- Update installation instructions to use correct setup script

## Testing

This ensures the GitHub Actions release workflow can successfully package all components without failing on missing files.

## Priority

**High** - This fixes the CI failure that prevented proper release artifact generation for v0.9.0.