### PR TITLE
Add demo video to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 UEMCP bridges AI assistants with Unreal Engine, enabling intelligent control of game development workflows through the Model Context Protocol (MCP).
 
+![UEMCP Demo](https://github.com/atomantic/UEMCP/releases/download/v1.0.0/uemcp-demo.gif)
+
 
 ## 🚀 Quick Start (2 minutes)
 


### PR DESCRIPTION
## Summary
• Add visual demo GIF showcasing UEMCP functionality directly in README
• Optimized 35-second demo video converted to 2.2MB GIF for fast loading
• Positioned after project description for immediate visual impact

## Test plan
- [x] Verify demo GIF displays correctly in README
- [x] Confirm file size is reasonable for GitHub (2.2MB)
- [x] Test that GitHub release asset link works properly

🤖 Generated with [Claude Code](https://claude.ai/code)