### PR TITLE
Make demo video full width in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 UEMCP bridges AI assistants with Unreal Engine, enabling intelligent control of game development workflows through the Model Context Protocol (MCP).
 
-![UEMCP Demo](https://github.com/atomantic/UEMCP/releases/download/v1.0.0/uemcp-demo.gif)
+<img src="https://github.com/atomantic/UEMCP/releases/download/v1.0.0/uemcp-demo.gif" alt="UEMCP Demo" width="100%">
 
 
 ## 🚀 Quick Start (2 minutes)


### PR DESCRIPTION
## Summary
• Change demo GIF from markdown image syntax to HTML img tag with width="100%"
• Provides better visual impact and utilizes full container width
• Improves presentation of the demo video in the README

## Test plan
- [x] Verify demo GIF displays at full width in README
- [x] Confirm HTML img tag renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.ai/code)